### PR TITLE
Do not bail on aws-cli versions >= 2.0

### DIFF
--- a/bin/aws-secrets-get
+++ b/bin/aws-secrets-get
@@ -12,8 +12,10 @@ SECRETS_FILE_NAME="secrets"
 
 which aws >/dev/null || die "aws-cli not found."
 
-major=`aws --version 2>&1 | awk '{print $1}' | sed 's|aws-cli/1.\([0-9]*\).*$|\1|'`
-[ ! -z "$major" ] && [ $major -lt 8 ] && die "aws-cli version needs to be >= 1.8."
+versions=`aws --version 2>&1 | awk '{print $1}' | sed 's|aws-cli/\([1-9][1-9]*\)\.\([0-9][0-9]*\).*$|\1,\2|'`
+major=`echo "$versions" | cut -d, -f1`
+minor=`echo "$versions" | cut -d, -f2`
+[ $major -lt 2  ] && [ $minor -lt 8 ] && die "aws-cli version needs to be >= 1.8."
 
 app=$APP_NAME
 [ -z "$app" ] && app=$1

--- a/bin/aws-secrets-get-file
+++ b/bin/aws-secrets-get-file
@@ -10,8 +10,10 @@ die() {
 
 which aws >/dev/null || die "aws-cli not found."
 
-major=`aws --version 2>&1 | awk '{print $1}' | sed 's|aws-cli/1.\([0-9]*\).*$|\1|'`
-[ ! -z "$major" ] && [ $major -lt 8 ] && die "aws-cli version needs to be >= 1.8."
+versions=`aws --version 2>&1 | awk '{print $1}' | sed 's|aws-cli/\([1-9][1-9]*\)\.\([0-9][0-9]*\).*$|\1,\2|'`
+major=`echo "$versions" | cut -d, -f1`
+minor=`echo "$versions" | cut -d, -f2`
+[ $major -lt 2  ] && [ $minor -lt 8 ] && die "aws-cli version needs to be >= 1.8."
 
 app=$1
 ver=$2

--- a/bin/aws-secrets-init-resources
+++ b/bin/aws-secrets-init-resources
@@ -11,8 +11,10 @@ die() {
 
 which aws >/dev/null || die "aws-cli not found."
 
-major=`aws --version 2>&1 | awk '{print $1}' | sed 's|aws-cli/1.\([0-9]*\).*$|\1|'`
-[ ! -z "$major" ] && [ $major -lt 8 ] && die "aws-cli version needs to be >= 1.8."
+versions=`aws --version 2>&1 | awk '{print $1}' | sed 's|aws-cli/\([1-9][1-9]*\)\.\([0-9][0-9]*\).*$|\1,\2|'`
+major=`echo "$versions" | cut -d, -f1`
+minor=`echo "$versions" | cut -d, -f2`
+[ $major -lt 2  ] && [ $minor -lt 8 ] && die "aws-cli version needs to be >= 1.8."
 
 # `base` is the base name for the config, used for the bucket name, keys, roles
 #   It can be used with multiple apps, each with multiple envs, and each set of secrets

--- a/bin/aws-secrets-purge-resources
+++ b/bin/aws-secrets-purge-resources
@@ -11,8 +11,10 @@ die() {
 
 which aws >/dev/null || die "aws-cli not found."
 
-major=`aws --version 2>&1 | awk '{print $1}' | sed 's|aws-cli/1.\([0-9]*\).*$|\1|'`
-[ ! -z "$major" ] && [ $major -lt 8 ] && die "aws-cli version needs to be >= 1.8."
+versions=`aws --version 2>&1 | awk '{print $1}' | sed 's|aws-cli/\([1-9][1-9]*\)\.\([0-9][0-9]*\).*$|\1,\2|'`
+major=`echo "$versions" | cut -d, -f1`
+minor=`echo "$versions" | cut -d, -f2`
+[ $major -lt 2  ] && [ $minor -lt 8 ] && die "aws-cli version needs to be >= 1.8."
 
 base=$AWS_SECRETS_BASE
 [ -z "$base" ] && base=$1

--- a/bin/aws-secrets-send
+++ b/bin/aws-secrets-send
@@ -14,8 +14,10 @@ SECRETS_FILE_NAME="secrets"
 
 which aws >/dev/null || die "aws-cli not found."
 
-major=`aws --version 2>&1 | awk '{print $1}' | sed 's|aws-cli/1.\([0-9]*\).*$|\1|'`
-[ ! -z "$major" ] && [ $major -lt 8 ] && die "aws-cli version needs to be >= 1.8."
+versions=`aws --version 2>&1 | awk '{print $1}' | sed 's|aws-cli/\([1-9][1-9]*\)\.\([0-9][0-9]*\).*$|\1,\2|'`
+major=`echo "$versions" | cut -d, -f1`
+minor=`echo "$versions" | cut -d, -f2`
+[ $major -lt 2  ] && [ $minor -lt 8 ] && die "aws-cli version needs to be >= 1.8."
 
 app=$APP_NAME
 [ -z "$app" ] && app=$1

--- a/bin/aws-secrets-send-file
+++ b/bin/aws-secrets-send-file
@@ -12,8 +12,10 @@ die() {
 
 which aws >/dev/null || die "aws-cli not found."
 
-major=`aws --version 2>&1 | awk '{print $1}' | sed 's|aws-cli/1.\([0-9]*\).*$|\1|'`
-[ ! -z "$major" ] && [ $major -lt 8 ] && die "aws-cli version needs to be >= 1.8."
+versions=`aws --version 2>&1 | awk '{print $1}' | sed 's|aws-cli/\([1-9][1-9]*\)\.\([0-9][0-9]*\).*$|\1,\2|'`
+major=`echo "$versions" | cut -d, -f1`
+minor=`echo "$versions" | cut -d, -f2`
+[ $major -lt 2  ] && [ $minor -lt 8 ] && die "aws-cli version needs to be >= 1.8."
 
 app=$1
 secrets_file=$2


### PR DESCRIPTION
Change version checking code that looks for minor version >= 8 to inspect
both major and minor versions and approve any version >= 1.8.

I'm not sure if the scripts all work with aws-cli 2.0, but I know that they
gave up without trying before, and this fixes that. It seems to run on my
system now.